### PR TITLE
Reorganize current exhibits

### DIFF
--- a/client/src/components/ExhibitCard.jsx
+++ b/client/src/components/ExhibitCard.jsx
@@ -1,12 +1,18 @@
 import { Card, CardBody } from "@chakra-ui/card";
-import { Stack, StackDivider, Flex } from "@chakra-ui/layout";
+import { Stack, StackDivider } from "@chakra-ui/layout";
 import ExhibitCardLinks from "./ExhibitCardLinks";
 
 function ExhibitCard() {
 	return (
-		<Card width="90%">
+		<Card
+			width="50%"
+			height="fit-content"
+			variant="outline"
+			borderColor="gray.300"
+			boxShadow="3px 3px 3px 3px rgba(0, 0, 0, 0.2)"
+		>
 			<CardBody textStyle="playfairBold">
-				<Stack divider={<StackDivider />} spacing="4">
+				<Stack divider={<StackDivider borderColor="gray.300" />} spacing="4">
 					<ExhibitCardLinks
 						// destination=""
 						justification="flex-start"

--- a/client/src/components/ExhibitImage.jsx
+++ b/client/src/components/ExhibitImage.jsx
@@ -5,17 +5,13 @@ function ExhibitImage({ destination, headingOne, headingTwo, src, alt, hoverText
 	const [isActive, setIsActive] = useState(false);
 
 	return (
-		<Box
-			position="relative"
-			display="inline-block"
-			marginBottom={{ sm: "5%", md: "10%", lg: "15%" }}
-		>
+		<Box position="relative" maxW="100%">
 			<Link destination={destination}>
-				<Heading variant="exhibit-heading" textAlign="left" fontSize="1.25em" pb={0}>
+				<Heading variant="exhibit-heading" textAlign="left" fontSize="1.3em" pb={0}>
 					{headingOne}
 				</Heading>
 			</Link>
-			<Heading variant="exhibit-heading" textAlign="left" fontSize="1.25em" pb={2}>
+			<Heading variant="exhibit-heading" textAlign="left" fontSize="1.3em" pb={2}>
 				{headingTwo}
 			</Heading>
 			<Box
@@ -25,12 +21,7 @@ function ExhibitImage({ destination, headingOne, headingTwo, src, alt, hoverText
 				onMouseLeave={() => setIsActive(false)}
 				onTouchStart={() => (isActive ? setIsActive(false) : setIsActive(true))}
 			>
-				<Image
-					src={src}
-					alt={alt}
-					borderRadius="sm"
-					style={{ maxWidth: "100%", height: "auto" }}
-				/>
+				<Image src={src} alt={alt} />
 				<Box
 					position="absolute"
 					bottom={0}
@@ -40,7 +31,6 @@ function ExhibitImage({ destination, headingOne, headingTwo, src, alt, hoverText
 					opacity={isActive ? 1 : 0}
 					transition="opacity 0.3s"
 					bgGradient="linear(to bottom, rgba(0,0,0,0.0) 0%, rgba(0,0,0,0.2) 20%, rgba(0,0,0,0.4) 40%, rgba(0,0,0,0.6) 60%, rgba(0,0,0,.8) 100%)"
-					borderRadius="sm"
 					p={3}
 					textStyle="battambang"
 				>

--- a/client/src/components/SectionHeader.jsx
+++ b/client/src/components/SectionHeader.jsx
@@ -1,0 +1,15 @@
+import { Box, Heading, Flex } from "@chakra-ui/react";
+
+function SectionHeader({ headerText }) {
+	return (
+		<Flex direction="column" width="100%" mb={6}>
+			<Heading variant="section-heading" fontSize="2.25em">
+				{headerText}
+			</Heading>
+			{/* border controlled seperately from text length */}
+			<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom={4} />
+		</Flex>
+	);
+}
+
+export default SectionHeader;

--- a/client/src/sections/CurrentExhibits.jsx
+++ b/client/src/sections/CurrentExhibits.jsx
@@ -5,6 +5,7 @@ import ExhibitImage from "../components/ExhibitImage";
 import ExhibitCard from "../components/ExhibitCard";
 
 function CurrentExhibits() {
+	// Old logic for detecting window width for responsive design
 	// const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 	// useEffect(() => {
@@ -24,9 +25,10 @@ function CurrentExhibits() {
 				spacingX={{ sm: 0, md: 4, lg: 8 }}
 				spacingY={{ base: 4, lg: 8 }}
 				justifyItems="center"
+				alignItems="center"
 			>
 				<ExhibitImage
-					destination=""
+					// destination=""
 					headingOne="Champions of Collage"
 					headingTwo="June '23 - June '24"
 					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
@@ -56,86 +58,3 @@ function CurrentExhibits() {
 }
 
 export default CurrentExhibits;
-
-// {
-// 	/* ternary to reorganize grid components depending on number of columns */
-// }
-//
-// 	windowWidth <= 768 ? (
-// 		<>
-// 			<Flex direction="column" align="center" justify="space-around" height="100%">
-// 				<Box width="100%" alignSelf="flex-start">
-// 					<Heading variant="section-heading" fontSize="2.25em">
-// 						Current Exhibits
-// 					</Heading>
-// 					{/* border controlled seperately from text length */}
-// 					<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom="5%" />
-// 				</Box>
-// 				<ExhibitImage
-// 					// destination=""
-// 					headingOne="Champions of Collage"
-// 					headingTwo="June '23 - June '24"
-// 					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
-// 					alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
-// 					hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
-// 				/>
-// 				<ExhibitImage
-// 					// destination=""
-// 					headingOne="The Art of Chance"
-// 					headingTwo="Feb '23 - Feb '24"
-// 					src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
-// 					alt="Excerpt from Jean Arp's According To The Laws Of Chance"
-// 					hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
-// 				/>
-// 				<ExhibitImage
-// 					// destination=""
-// 					headingOne="Duchamp's Readymades"
-// 					headingTwo="Closing Sept. '23"
-// 					src="/images/DuchampTheFountain.jpg"
-// 					alt="Marcel Duchamp and his most well-known Readymade The Fountain"
-// 					hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
-// 				/>
-// 				<ExhibitCard />
-// 			</Flex>
-// 		</>
-// 	) : (
-// 		<>
-// 			<Flex direction="column" align="center" justify="space-around" height="100%">
-// 				<Box width="100%" alignSelf="flex-start">
-// 					<Heading variant="section-heading" fontSize="2.25em">
-// 						Current Exhibits
-// 					</Heading>
-// 					<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom="10%" />
-// 				</Box>
-// 				<ExhibitImage
-// 					// destination=""
-// 					headingOne="The Art of Chance"
-// 					headingTwo="Feb '23 - Feb '24"
-// 					src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
-// 					alt="Excerpt from Jean Arp's According To The Laws Of Chance"
-// 					hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
-// 				/>
-// 				<ExhibitCard />
-// 			</Flex>
-
-// 			<Flex direction="column" pt={12}>
-// 				<ExhibitImage
-// 					// destination=""
-// 					headingOne="Champions of Collage"
-// 					headingTwo="June '23 - June '24"
-// 					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
-// 					alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
-// 					hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
-// 				/>
-// 				<ExhibitImage
-// 					// destination=""
-// 					headingOne="Duchamp's Readymades"
-// 					headingTwo="Closing Sept. '23"
-// 					src="/images/DuchampTheFountain.jpg"
-// 					alt="Marcel Duchamp and his most well-known Readymade, The Fountain"
-// 					hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
-// 				/>
-// 			</Flex>
-// 		</>
-// 	);
-// }

--- a/client/src/sections/CurrentExhibits.jsx
+++ b/client/src/sections/CurrentExhibits.jsx
@@ -1,109 +1,141 @@
 import { Box, SimpleGrid, Heading, Flex } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
+import SectionHeader from "../components/SectionHeader";
 import ExhibitImage from "../components/ExhibitImage";
 import ExhibitCard from "../components/ExhibitCard";
 
 function CurrentExhibits() {
-	const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+	// const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
-	useEffect(() => {
-		const handleResize = () => {
-			setWindowWidth(window.innerWidth);
-			// console.log(windowWidth);
-		};
+	// useEffect(() => {
+	// 	const handleResize = () => {
+	// 		setWindowWidth(window.innerWidth);
+	// 		// console.log(windowWidth);
+	// 	};
 
-		window.addEventListener("resize", handleResize);
-	}, [window.innerWidth]);
+	// 	window.addEventListener("resize", handleResize);
+	// }, [window.innerWidth]);
 
 	return (
-		<Box paddingY={6} mx={{ sm: 8, md: 8, lg: 16 }}>
-			{/* Sets up responsive grid with two columns on larger screens, one column on smaller */}
+		<Box my={6} mx={{ sm: 8, md: 8, lg: 16 }}>
+			<SectionHeader headerText="Current Exhibits" />
 			<SimpleGrid
 				columns={{ sm: 1, md: 2 }}
-				spacingX={{ sm: 0, md: 8, lg: 16 }}
-				spacingY={20}
+				spacingX={{ sm: 0, md: 4, lg: 8 }}
+				spacingY={{ base: 4, lg: 8 }}
+				justifyItems="center"
 			>
-				{/* ternary to reorganize grid components depending on numbrer of columns */}
-				{windowWidth <= 768 ? (
-					<>
-						<Flex direction="column" align="center" justify="space-around" height="100%">
-							<Box width="100%" alignSelf="flex-start">
-								<Heading variant="section-heading" fontSize="2.25em">
-									Current Exhibits
-								</Heading>
-								{/* border controlled seperately from text length */}
-								<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom="5%" />
-							</Box>
-							<ExhibitImage
-								// destination=""
-								headingOne="Champions of Collage"
-								headingTwo="June '23 - June '24"
-								src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
-								alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
-								hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
-							/>
-							<ExhibitImage
-								// destination=""
-								headingOne="The Art of Chance"
-								headingTwo="Feb '23 - Feb '24"
-								src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
-								alt="Excerpt from Jean Arp's According To The Laws Of Chance"
-								hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
-							/>
-							<ExhibitImage
-								// destination=""
-								headingOne="Duchamp's Readymades"
-								headingTwo="Closing Sept. '23"
-								src="/images/DuchampTheFountain.jpg"
-								alt="Marcel Duchamp and his most well-known Readymade The Fountain"
-								hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
-							/>
-							<ExhibitCard />
-						</Flex>
-					</>
-				) : (
-					<>
-						<Flex direction="column" align="center" justify="space-around" height="100%">
-							<Box width="100%" alignSelf="flex-start">
-								<Heading variant="section-heading" fontSize="2.25em">
-									Current Exhibits
-								</Heading>
-								<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom="10%" />
-							</Box>
-							<ExhibitImage
-								// destination=""
-								headingOne="The Art of Chance"
-								headingTwo="Feb '23 - Feb '24"
-								src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
-								alt="Excerpt from Jean Arp's According To The Laws Of Chance"
-								hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
-							/>
-							<ExhibitCard />
-						</Flex>
-
-						<Flex direction="column" pt={12}>
-							<ExhibitImage
-								// destination=""
-								headingOne="Champions of Collage"
-								headingTwo="June '23 - June '24"
-								src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
-								alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
-								hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
-							/>
-							<ExhibitImage
-								// destination=""
-								headingOne="Duchamp's Readymades"
-								headingTwo="Closing Sept. '23"
-								src="/images/DuchampTheFountain.jpg"
-								alt="Marcel Duchamp and his most well-known Readymade, The Fountain"
-								hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
-							/>
-						</Flex>
-					</>
-				)}
+				<ExhibitImage
+					destination=""
+					headingOne="Champions of Collage"
+					headingTwo="June '23 - June '24"
+					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
+					alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
+					hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
+				/>
+				<ExhibitImage
+					// destination=""
+					headingOne="The Art of Chance"
+					headingTwo="Feb '23 - Feb '24"
+					src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
+					alt="Excerpt from Jean Arp's According To The Laws Of Chance"
+					hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
+				/>
+				<ExhibitImage
+					// destination=""
+					headingOne="Duchamp's Readymades"
+					headingTwo="Closing Sept. '23"
+					src="/images/DuchampTheFountain.jpg"
+					alt="Marcel Duchamp and his most well-known Readymade The Fountain"
+					hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
+				/>
+				<ExhibitCard />
 			</SimpleGrid>
 		</Box>
 	);
 }
 
 export default CurrentExhibits;
+
+// {
+// 	/* ternary to reorganize grid components depending on number of columns */
+// }
+//
+// 	windowWidth <= 768 ? (
+// 		<>
+// 			<Flex direction="column" align="center" justify="space-around" height="100%">
+// 				<Box width="100%" alignSelf="flex-start">
+// 					<Heading variant="section-heading" fontSize="2.25em">
+// 						Current Exhibits
+// 					</Heading>
+// 					{/* border controlled seperately from text length */}
+// 					<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom="5%" />
+// 				</Box>
+// 				<ExhibitImage
+// 					// destination=""
+// 					headingOne="Champions of Collage"
+// 					headingTwo="June '23 - June '24"
+// 					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
+// 					alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
+// 					hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
+// 				/>
+// 				<ExhibitImage
+// 					// destination=""
+// 					headingOne="The Art of Chance"
+// 					headingTwo="Feb '23 - Feb '24"
+// 					src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
+// 					alt="Excerpt from Jean Arp's According To The Laws Of Chance"
+// 					hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
+// 				/>
+// 				<ExhibitImage
+// 					// destination=""
+// 					headingOne="Duchamp's Readymades"
+// 					headingTwo="Closing Sept. '23"
+// 					src="/images/DuchampTheFountain.jpg"
+// 					alt="Marcel Duchamp and his most well-known Readymade The Fountain"
+// 					hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
+// 				/>
+// 				<ExhibitCard />
+// 			</Flex>
+// 		</>
+// 	) : (
+// 		<>
+// 			<Flex direction="column" align="center" justify="space-around" height="100%">
+// 				<Box width="100%" alignSelf="flex-start">
+// 					<Heading variant="section-heading" fontSize="2.25em">
+// 						Current Exhibits
+// 					</Heading>
+// 					<Box width="100%" borderBottom="5px solid #D17B7B" marginBottom="10%" />
+// 				</Box>
+// 				<ExhibitImage
+// 					// destination=""
+// 					headingOne="The Art of Chance"
+// 					headingTwo="Feb '23 - Feb '24"
+// 					src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
+// 					alt="Excerpt from Jean Arp's According To The Laws Of Chance"
+// 					hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
+// 				/>
+// 				<ExhibitCard />
+// 			</Flex>
+
+// 			<Flex direction="column" pt={12}>
+// 				<ExhibitImage
+// 					// destination=""
+// 					headingOne="Champions of Collage"
+// 					headingTwo="June '23 - June '24"
+// 					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
+// 					alt="Excerpt from Hannah Höch's Cut with the Dada Kitchen Knife through the Last Weimar Beer-Belly Cultural Epoch in Germany"
+// 					hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
+// 				/>
+// 				<ExhibitImage
+// 					// destination=""
+// 					headingOne="Duchamp's Readymades"
+// 					headingTwo="Closing Sept. '23"
+// 					src="/images/DuchampTheFountain.jpg"
+// 					alt="Marcel Duchamp and his most well-known Readymade, The Fountain"
+// 					hoverText="Ordinary objects presented in extraordinary places. A term coined by the titular artist in th 1910s, Readymades test the art worlds willingness to open its definition of 'art.' "
+// 				/>
+// 			</Flex>
+// 		</>
+// 	);
+// }

--- a/client/src/theme/heading.js
+++ b/client/src/theme/heading.js
@@ -14,7 +14,7 @@ const sectionHeading = defineStyle({
 	fontFamily: "Playfair Display, serif",
 	letterSpacing: "0.35em",
 	lineHeight: "1.5em",
-	textAlign: "center",
+	textAlign: { base: "center", lg: "left" },
 });
 
 const firstD = defineStyle({


### PR DESCRIPTION
Sets up a better grid for the current exhibits section. Separates out header into its own component. Redoes style of Exhibit Card component. In general, some massaging of margins/padding and design.