### PR TITLE
Loaders and divider line

### DIFF
--- a/client/src/components/Loader.jsx
+++ b/client/src/components/Loader.jsx
@@ -1,70 +1,54 @@
-// // import { CircularProgress, Box } from "@chakra-ui/react";
+import { CircularProgress, Flex, Box } from "@chakra-ui/react";
 
-// // const Loader = () => {
-// // 	return (
-// // 		<Box display="flex" justifyContent="center">
-// // 			<CircularProgress isIndeterminate color="green.300" position="relative">
-// // 				<CircularProgress isIndeterminate color="purple" height="2px" />
-// // 			</CircularProgress>
-// // 		</Box>
-// // 	);
-// // };
+const Loader = () => {
+	return (
+		<Box position="relative">
+			<CircularProgress
+				capIsRound
+				isIndeterminate
+				value={75}
+				color="#53443D"
+				thickness="5px"
+				trackColor="gray.100"
+				position="absolute"
+				transform="scale(2)"
+				bottom={0}
+			/>
+			<CircularProgress
+				capIsRound
+				isIndeterminate
+				value={75}
+				color="#B1BAC1"
+				thickness="6.75px"
+				trackColor="gray.100"
+				position="absolute"
+				transform="scale(1.5) scaleX(-1) rotate(-60deg)"
+				bottom={0}
+			/>
+			<CircularProgress
+				capIsRound
+				isIndeterminate
+				value={75}
+				thickness="9.5px"
+				color="#53443D"
+				trackColor="gray.100"
+				position="absolute"
+				bottom={0}
+				transform="scale(1)"
+			/>
+			<CircularProgress
+				capIsRound
+				isIndeterminate
+				value={75}
+				thickness="17px"
+				color="#B1BAC1"
+				trackColor="gray.100"
+				position="absolute"
+				bottom={0}
+				transform="scale(.5) scaleX(-1) rotate(-60deg)"
+			/>
+		</Box>
+	);
+};
 
-// // export default Loader;
-
-// import { CircularProgress, Box } from "@chakra-ui/react";
-
-// const Loader = () => {
-// 	return (
-// 		<Box display="flex" alignItems="center" justifyContent="center">
-// 			<Box position="relative">
-// 				<CircularProgress
-// 					value={75}
-// 					size="120px"
-// 					thickness="8px"
-// 					color="blue.500"
-// 					emptyColor="gray.200"
-// 					trackColor="transparent"
-// 					capIsRound
-// 					sx={{
-// 						position: "absolute",
-// 						zIndex: 2,
-// 						animation: "rotate 2s infinite linear",
-// 						"@keyframes rotate": {
-// 							"0%": {
-// 								transform: "rotate(180deg)",
-// 							},
-// 							"100%": {
-// 								transform: "rotate(-180deg)",
-// 							},
-// 						},
-// 					}}
-// 				/>
-// 				<CircularProgress
-// 					value={50}
-// 					size="60px"
-// 					thickness="8px"
-// 					color="green.500"
-// 					emptyColor="transparent"
-// 					trackColor="transparent"
-// 					capIsRound
-// 					sx={{
-// 						position: "absolute",
-// 						zIndex: 1,
-// 						animation: "rotate 2s infinite linear",
-// 						"@keyframes rotate": {
-// 							"0%": {
-// 								transform: "rotate(0deg)",
-// 							},
-// 							"100%": {
-// 								transform: "rotate(360deg)",
-// 							},
-// 						},
-// 					}}
-// 				/>
-// 			</Box>
-// 		</Box>
-// 	);
-// };
-
-// export default Loader;
+export default Loader;

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -1,5 +1,4 @@
-import { Box, Flex, Grid, Button, Image } from "@chakra-ui/react";
-// import Button from "../components/Button.jsx";
+import { Box, Flex, Grid, Image, Divider } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import SectionHeader from "../components/SectionHeader";
 import FeaturedImage from "../components/FeaturedImage";
@@ -218,7 +217,7 @@ function Featured() {
 		<Box py={6} mx={{ sm: 8, md: 8, lg: 16 }}>
 			<SectionHeader headerText="Featured Artist" />
 			<Grid
-				templateColumns={{ base: "1fr", lg: "2fr 3fr" }}
+				templateColumns={{ base: "1fr", lg: "2.5fr .25fr 3fr" }}
 				height={{ base: "auto", lg: "40vw" }}
 				gap={{ sm: 4, md: 8, lg: 16 }}
 				mx="5%"
@@ -287,6 +286,7 @@ function Featured() {
 						</Flex>
 					</Flex>
 				</Flex>
+				<Divider mt={4} height="90%" borderColor="#B1BAC1" orientation="vertical" />
 				<Box
 					// ref={scrollBoxRef}
 					overflowY={{ base: "hidden", lg: "scroll" }}

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import SectionHeader from "../components/SectionHeader";
 import FeaturedImage from "../components/FeaturedImage";
 import Button2 from "../components/Button2";
-// import Loader from "../components/Loader";
+import Loader from "../components/Loader";
 
 function Featured() {
 	// establish states for the featured artist
@@ -238,7 +238,9 @@ function Featured() {
 						height="80%"
 					>
 						{loadingArtist ? (
-							<Box height="80%">Loading...</Box>
+							<Flex justify="center" height="90%" align="center">
+								<Loader />
+							</Flex>
 						) : (
 							<>
 								<Flex
@@ -282,7 +284,6 @@ function Featured() {
 						<Flex direction="row" justify="space-between" gap={3}>
 							<Button2 buttonText="Randomize Artist" functionCall={handleClickArtist} />
 							<Button2 buttonText="Randomize Art" functionCall={handleClickArt} />
-							{/* <Loader /> */}
 						</Flex>
 					</Flex>
 				</Flex>
@@ -318,7 +319,9 @@ function Featured() {
 						)}
 					</Box> */}
 					{loadingArt ? (
-						<Box>Loading...</Box>
+						<Flex justify="center" height="80%" align="center">
+							<Loader />
+						</Flex>
 					) : (
 						<Flex
 							direction={{ base: "row", lg: "column" }}


### PR DESCRIPTION
Built a loader using Chakra UI's circular progress bar. Places it and centers it for desktop display – issues with rendering on mobile/smaller screens.

Places a divider line for desktop. Similar issue for mobile.