### PR TITLE
Loader center scroll blur

### DIFF
--- a/client/src/components/BrandButton.jsx
+++ b/client/src/components/BrandButton.jsx
@@ -9,17 +9,20 @@ function BrandButton({ buttonText, functionCall }) {
 			border="1px solid #B1BAC1"
 			bg="gray.100"
 			color="#53443D"
+			boxShadow="md"
 			_hover={{
 				bg: "#53443D",
 				color: "gray.100",
-				boxShadow: "1px 1px 1px 1px rgba(0, 0, 0, 0.2)",
+				boxShadow: "dark-lg",
 				transform: "scale(1.05) translate(-2px, -2px)",
 				zIndex: "1",
 			}}
 			_active={{
 				color: "#B1BAC1",
-				boxShadow: "inset 2px 2px 2px 2px rgba(0, 0, 0, 0.2)",
+				bg: "#53443D",
+				boxShadow: "inset -1px -1px 4px 3px rgba(0, 0, 0, .4)",
 				transform: "scale(1) translate(0px, 0px)",
+				transition: "all 0.3s ease",
 			}}
 			py={{ base: 2, md: 4 }}
 			px={{ base: 2, md: 4 }}

--- a/client/src/components/ButtonLink.jsx
+++ b/client/src/components/ButtonLink.jsx
@@ -11,16 +11,18 @@ function ButtonLink({ buttonText, link }) {
 			border="1px solid #B1BAC1"
 			bg="gray.100"
 			color="#53443D"
+			boxShadow="md"
 			_hover={{
 				bg: "#53443D",
 				color: "gray.100",
-				boxShadow: "1px 1px 1px 1px rgba(0, 0, 0, 0.2)",
+				boxShadow: "dark-lg",
 				transform: "scale(1.05) translate(-2px, -2px)",
 				zIndex: "1",
 			}}
 			_active={{
 				color: "#B1BAC1",
-				boxShadow: "inset 2px 2px 2px 2px rgba(0, 0, 0, 0.2)",
+				bg: "#53443D",
+				boxShadow: "inset -1px -1px 4px 3px rgba(0, 0, 0, .4)",
 				transform: "scale(1) translate(0px, 0px)",
 			}}
 			py={{ base: 4, lg: 6 }}

--- a/client/src/components/ExhibitImage.jsx
+++ b/client/src/components/ExhibitImage.jsx
@@ -7,8 +7,14 @@ function ExhibitImage({ destination, headingOne, headingTwo, src, alt, hoverText
 
 	return (
 		<Box position="relative" maxW="100%">
-			<Link to="/link">
-				<Heading variant="exhibit-heading" textAlign="left" fontSize="1.3em" pb={0} _hover={{textDecorationLine: "underline", color: "#B1BAC1"}}>
+			<Link to={destination}>
+				<Heading
+					variant="exhibit-heading"
+					textAlign="left"
+					fontSize="1.3em"
+					pb={0}
+					_hover={{ textDecorationLine: "underline", color: "#B1BAC1" }}
+				>
 					{headingOne}
 				</Heading>
 			</Link>
@@ -22,7 +28,7 @@ function ExhibitImage({ destination, headingOne, headingTwo, src, alt, hoverText
 				onMouseLeave={() => setIsActive(false)}
 				onTouchStart={() => (isActive ? setIsActive(false) : setIsActive(true))}
 			>
-				<Image src={src} alt={alt} borderRadius="md" />
+				<Image src={src} alt={alt} borderRadius="md" boxShadow="dark-lg" />
 				<Box
 					position="absolute"
 					bottom={0}

--- a/client/src/components/FeaturedImage.jsx
+++ b/client/src/components/FeaturedImage.jsx
@@ -26,7 +26,14 @@ function FeaturedImage({ flexDirection, alignment, textAlign, title, date, url, 
 					{date}
 				</Box>
 			</Flex>
-			<Image src={url} alt={alt} maxW={{ base: "70%", lg: "35%" }} borderRadius="md" />
+			<Image
+				src={url}
+				alt={alt}
+				maxW={{ base: "70%", lg: "35%" }}
+				borderRadius="md"
+				zIndex="0"
+				boxShadow="1px 3px 6px rgba(0, 0, 0, 0.3)"
+			/>
 		</Flex>
 	);
 }

--- a/client/src/components/FeaturedImage.jsx
+++ b/client/src/components/FeaturedImage.jsx
@@ -8,7 +8,7 @@ function FeaturedImage({ flexDirection, alignment, textAlign, title, date, url, 
 			justify="space-evenly"
 			mb={{ base: 0, lg: 8 }}
 			mx={{ base: 4, lg: 0 }}
-			height={{ base: "55vw", lg: "auto" }}
+			height={{ base: "45vh", lg: "auto" }}
 		>
 			<Flex direction="column" align={alignment} width={{ base: "75%", lg: "30%" }}>
 				<Box

--- a/client/src/components/FeaturedImage.jsx
+++ b/client/src/components/FeaturedImage.jsx
@@ -8,7 +8,7 @@ function FeaturedImage({ flexDirection, alignment, textAlign, title, date, url, 
 			justify="space-evenly"
 			mb={{ base: 0, lg: 8 }}
 			mx={{ base: 4, lg: 0 }}
-			height={{ base: "45vh", lg: "auto" }}
+			height={{ base: "50vh", lg: "auto" }}
 		>
 			<Flex direction="column" align={alignment} width={{ base: "75%", lg: "30%" }}>
 				<Box

--- a/client/src/components/Loader.jsx
+++ b/client/src/components/Loader.jsx
@@ -1,8 +1,8 @@
-import { CircularProgress, Flex, Box } from "@chakra-ui/react";
+import { CircularProgress, Flex } from "@chakra-ui/react";
 
-function Loader({ number }) {
+function Loader({ marginBottom }) {
 	return (
-		<Box position="relative" width="100px" height="100px" mb={number}>
+		<Flex justify="center" align="center" width="100px" height="100px" mb={marginBottom}>
 			<CircularProgress
 				capIsRound
 				isIndeterminate
@@ -12,7 +12,6 @@ function Loader({ number }) {
 				trackColor="gray.100"
 				position="absolute"
 				transform="scale(2)"
-				bottom={0}
 			/>
 			<CircularProgress
 				capIsRound
@@ -23,7 +22,6 @@ function Loader({ number }) {
 				trackColor="gray.100"
 				position="absolute"
 				transform="scale(1.5) scaleX(-1) rotate(-60deg)"
-				bottom={0}
 			/>
 			<CircularProgress
 				capIsRound
@@ -33,7 +31,6 @@ function Loader({ number }) {
 				color="#53443D"
 				trackColor="gray.100"
 				position="absolute"
-				bottom={0}
 				transform="scale(1)"
 			/>
 			<CircularProgress
@@ -44,10 +41,9 @@ function Loader({ number }) {
 				color="#B1BAC1"
 				trackColor="gray.100"
 				position="absolute"
-				bottom={0}
 				transform="scale(.5) scaleX(-1) rotate(-60deg)"
 			/>
-		</Box>
+		</Flex>
 	);
 }
 

--- a/client/src/components/SectionHeader.jsx
+++ b/client/src/components/SectionHeader.jsx
@@ -7,7 +7,7 @@ function SectionHeader({ headerText }) {
 				{headerText}
 			</Heading>
 
-			<Box borderBottom="2px solid #B1BAC1" marginBottom={4} borderRadius="md" />
+			<Box borderBottom="2px solid #B1BAC1" borderRadius="md" />
 		</Flex>
 	);
 }

--- a/client/src/pages/LinkDestination.jsx
+++ b/client/src/pages/LinkDestination.jsx
@@ -27,7 +27,7 @@ function LinkDestination() {
 					item, so the links don't lead anywhere. Click the button below to return to the
 					homepage.
 				</Text>
-				<Box width="25%">
+				<Box width="50%">
 					<ButtonLink buttonText="Return to Homepage" link="/" />
 				</Box>
 			</Box>

--- a/client/src/sections/Collage.jsx
+++ b/client/src/sections/Collage.jsx
@@ -58,7 +58,12 @@ function Collage() {
 	};
 
 	return (
-		<Box paddingY={6} w="100%" backgroundColor="gray.100">
+		<Box
+			paddingY={6}
+			w="100%"
+			backgroundColor="gray.100"
+			boxShadow="inset 4px 4px 10px rgba(0, 0, 0, 0.2), inset -4px -8px 10px rgba(0, 0, 0, 0.2)"
+		>
 			<Box mx={{ sm: 8, md: 8, lg: 16 }}>
 				<SectionHeader headerText="Make a Collage" />
 				<Box

--- a/client/src/sections/CurrentExhibits.jsx
+++ b/client/src/sections/CurrentExhibits.jsx
@@ -32,7 +32,7 @@ function CurrentExhibits() {
 				alignItems="center"
 			>
 				<ExhibitImage
-					// destination=""
+					destination="/link"
 					headingOne="Champions of Collage"
 					headingTwo="June '23 - June '24"
 					src="/images/DetailCutWithTheKitchenKnifeHoch.jpg"
@@ -40,7 +40,7 @@ function CurrentExhibits() {
 					hoverText="Tracing the evolution of photomontage and collage in the early 20th century, this exhibit highlights works by Kurt Schwitters, William S. Burroughs, and others whose innovative approach transformed the art world."
 				/>
 				<ExhibitImage
-					// destination=""
+					destination="/link"
 					headingOne="The Art of Chance"
 					headingTwo="Feb '23 - Feb '24"
 					src="/images/ExcerptAccordingToTheLawsOfChanceJeanArp.jpeg"
@@ -48,7 +48,7 @@ function CurrentExhibits() {
 					hoverText="Explore the role of randomness in the creative process of Dada artists like Jean Arp, Francis Picabia, and Marcel Duchamp, as they sought to embrace chance, errors, and the unexpected in their art-making process."
 				/>
 				<ExhibitImage
-					// destination=""
+					destination="/link"
 					headingOne="Duchamp's Readymades"
 					headingTwo="Closing Sept. '23"
 					src="/images/DuchampTheFountain.jpg"

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -302,7 +302,7 @@ function Featured() {
 						height={{ base: "fit-content", lg: "auto" }}
 						borderRadius="md"
 					>
-						{scrollDirection.left && (
+						{/* {scrollDirection.left && (
 							<Box
 								position="sticky"
 								pointerEvents="none"
@@ -318,12 +318,13 @@ function Featured() {
 								position="sticky"
 								pointerEvents="none"
 								width="100%"
-								height="20px"
 								top="0"
+								height="15%"
+								transition="top 0.5s ease-in-out"
 								zIndex="1"
-								bg="blue.800"
+								bgGradient="linear(to top, rgba(255, 255, 255, 0.0), rgba(255, 255, 255, 0.1),rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 1))"
 							/>
-						)}
+						)} */}
 						<Flex
 							direction={{ base: "row", lg: "column" }}
 							width={{ base: "330%", md: "270%", lg: "auto" }}
@@ -357,7 +358,8 @@ function Featured() {
 								);
 							})}
 						</Flex>
-						{scrollDirection.right && (
+
+						{/* {scrollDirection.right && (
 							<Box
 								position="sticky"
 								width="20px"
@@ -372,12 +374,12 @@ function Featured() {
 								position="sticky"
 								pointerEvents="none"
 								width="100%"
-								height="20px"
-								bottom="0"
+								height="15%"
+								bottom="-1"
 								zIndex="1"
-								bg="pink.800"
+								background="linear-gradient(to bottom, rgba(255, 255, 255, 0.0), rgba(255, 255, 255, 0.1),rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 1))"
 							/>
-						)}
+						)} */}
 					</Box>
 				)}
 			</Grid>

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -160,53 +160,59 @@ function Featured() {
 		fillFeaturedArtistImages();
 	};
 
-	// const scrollBoxRef = useRef(null);
+	const [scrollDirection, setScrollDirection] = useState({
+		left: false,
+		right: false,
+		up: false,
+		down: true,
+	});
+	const scrollBoxRef = useRef(null);
 
-	// useEffect(() => {
-	// 	const scrollBox = scrollBoxRef.current;
+	useEffect(() => {
+		const scrollBox = scrollBoxRef.current;
 
-	// 	// if check to see window size and set scrollDirection accordingly
-	// 	if (window.innerWidth < 992) {
-	// 		setScrollDirection({
-	// 			left: false,
-	// 			right: true,
-	// 			up: false,
-	// 			down: false,
-	// 		});
-	// 	}
+		// if check to see window size and set scrollDirection accordingly
+		if (window.innerWidth < 992) {
+			setScrollDirection({
+				left: false,
+				right: true,
+				up: false,
+				down: false,
+			});
+		}
 
-	// 	if (!scrollBox) {
-	// 		return;
-	// 	}
+		if (!scrollBox) {
+			return;
+		}
 
-	// 	const handleScroll = () => {
-	// 		const isScrollableX = scrollBox.scrollWidth > scrollBox.clientWidth;
-	// 		const isScrollableY = scrollBox.scrollHeight > scrollBox.clientHeight;
+		const handleScroll = () => {
+			const isScrollableX = scrollBox.scrollWidth > scrollBox.clientWidth;
+			const isScrollableY = scrollBox.scrollHeight > scrollBox.clientHeight;
 
-	// 		setScrollDirection({
-	// 			left: scrollBox.scrollLeft > 0 && isScrollableX,
-	// 			right:
-	// 				scrollBox.scrollLeft < scrollBox.scrollWidth - scrollBox.clientWidth &&
-	// 				isScrollableX,
-	// 			up: scrollBox.scrollTop > 0 && isScrollableY,
-	// 			down:
-	// 				scrollBox.scrollTop < scrollBox.scrollHeight - scrollBox.clientHeight &&
-	// 				isScrollableY,
-	// 		});
-	// 	};
+			setScrollDirection({
+				left: scrollBox.scrollLeft > 0 && isScrollableX,
+				right:
+					scrollBox.scrollLeft < scrollBox.scrollWidth - scrollBox.clientWidth &&
+					isScrollableX,
+				up: scrollBox.scrollTop > 0 && isScrollableY,
+				down:
+					scrollBox.scrollTop < scrollBox.scrollHeight - scrollBox.clientHeight &&
+					isScrollableY,
+			});
+		};
 
-	// 	scrollBox.addEventListener("scroll", handleScroll);
-	// 	window.addEventListener("resize", handleScroll);
+		scrollBox.addEventListener("scroll", handleScroll);
+		window.addEventListener("resize", handleScroll);
 
-	// 	return () => {
-	// 		scrollBox.removeEventListener("scroll", handleScroll);
-	// 		window.removeEventListener("resize", handleScroll);
-	// 	};
-	// }, [loadingArt]);
+		return () => {
+			scrollBox.removeEventListener("scroll", handleScroll);
+			window.removeEventListener("resize", handleScroll);
+		};
+	}, [loadingArt]);
 
-	// useEffect(() => {
-	// 	console.log(scrollDirection);
-	// }, [scrollDirection]);
+	useEffect(() => {
+		console.log(scrollDirection);
+	}, [scrollDirection]);
 
 	return (
 		<Box py={6} mx={{ sm: 8, md: 8, lg: 16 }}>
@@ -288,36 +294,36 @@ function Featured() {
 					</Flex>
 				) : (
 					<Box
-						// ref={scrollBoxRef}
-						overflowY={{ base: "auto", lg: "scroll" }}
+						ref={scrollBoxRef}
+						overflowY={{ base: "hidden", lg: "scroll" }}
 						overflowX={{ base: "scroll", lg: "hidden" }}
 						position="relative"
 						width="100%"
 						height={{ base: "fit-content", lg: "auto" }}
 						borderRadius="md"
 					>
-						{/* <Box pointerEvents="none" width="100%" height="100%" position="absolute">
-							{scrollDirection.left && (
-								<Box position="absolute" height="100%" left="0" zIndex="1">
-									Left
-								</Box>
-							)}
-							{scrollDirection.right && (
-								<Box position="absolute" height="100%" right="0" zIndex="1">
-									Right
-								</Box>
-							)}
-							{scrollDirection.up && (
-								<Box position="absolute" width="100%" top="0" zIndex="1">
-									Up
-								</Box>
-							)}
-							{scrollDirection.down && (
-								<Box position="absolute" width="100%" bottom="0" zIndex="1">
-									Down
-								</Box>
-							)}
-						</Box> */}
+						{scrollDirection.left && (
+							<Box
+								position="sticky"
+								pointerEvents="none"
+								width="20px"
+								height="60vh"
+								left="0"
+								zIndex="1"
+								bg="gray.800"
+							/>
+						)}
+						{scrollDirection.up && (
+							<Box
+								position="sticky"
+								pointerEvents="none"
+								width="100%"
+								height="20px"
+								top="0"
+								zIndex="1"
+								bg="blue.800"
+							/>
+						)}
 						<Flex
 							direction={{ base: "row", lg: "column" }}
 							width={{ base: "330%", md: "270%", lg: "auto" }}
@@ -351,6 +357,27 @@ function Featured() {
 								);
 							})}
 						</Flex>
+						{scrollDirection.right && (
+							<Box
+								position="sticky"
+								width="20px"
+								height="60vh"
+								right="0"
+								zIndex="1"
+								bg="green.800"
+							></Box>
+						)}
+						{scrollDirection.down && (
+							<Box
+								position="sticky"
+								pointerEvents="none"
+								width="100%"
+								height="20px"
+								bottom="0"
+								zIndex="1"
+								bg="pink.800"
+							/>
+						)}
 					</Box>
 				)}
 			</Grid>

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -246,6 +246,7 @@ function Featured() {
 									src={selectedArtist.src}
 									alt={selectedArtist.alt}
 									borderRadius="md"
+									boxShadow="dark-lg"
 								/>
 								<Box
 									padding="5px"
@@ -295,12 +296,14 @@ function Featured() {
 				) : (
 					<Box
 						ref={scrollBoxRef}
+						pt={4}
 						overflowY={{ base: "hidden", lg: "scroll" }}
 						overflowX={{ base: "scroll", lg: "hidden" }}
 						position="relative"
 						width="100%"
 						height={{ base: "fit-content", lg: "auto" }}
 						borderRadius="md"
+						boxShadow="inset 1px 1px 6px rgba(0, 0, 0, 0.4)"
 					>
 						{/* {scrollDirection.left && (
 							<Box

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -230,19 +230,12 @@ function Featured() {
 			<SectionHeader headerText="Featured Artist" />
 			<Grid
 				templateColumns={{ base: "1fr", lg: "2.5fr .25fr 3fr" }}
-				// templateRows={{ base: "1fr .00001fr 1fr", lg: "1fr" }}
 				height={{ base: "auto", lg: "40vw" }}
-				gap={{ sm: 4, md: 8, lg: 16 }}
-				mx="5%"
+				mx={{ base: "0", lg: "5%" }}
+				gap="5%"
 			>
 				{loadingArtist ? (
-					<Flex
-						justify="center"
-						direction="column"
-						width="100%"
-						height="100%"
-						align="center"
-					>
+					<Flex justify="center" align="center" mb={{ base: 6, lg: 0 }}>
 						<Loader />
 					</Flex>
 				) : (
@@ -258,7 +251,7 @@ function Featured() {
 							justify="space-between"
 							align="center"
 							width="100%"
-							height="80%"
+							height="90%"
 						>
 							<Flex
 								justify="center"
@@ -310,22 +303,11 @@ function Featured() {
 				{windowWidth >= 992 ? (
 					<Divider mt={4} height="90%" borderColor="#B1BAC1" orientation="vertical" />
 				) : (
-					<Divider
-						mt={12}
-						borderColor="#B1BAC1"
-						orientation="horizontal"
-						justifySelf="center"
-					/>
+					<Divider borderColor="#B1BAC1" orientation="horizontal" />
 				)}
 				{loadingArt ? (
-					<Flex
-						direction="column"
-						justify="center"
-						width="100%"
-						height="100%"
-						align="center"
-					>
-						<Loader number={{ base: 20, lg: 0 }} />
+					<Flex justify="center" align="center" my={{ base: 6, lg: 0 }}>
+						<Loader />
 					</Flex>
 				) : (
 					<Box

--- a/client/src/sections/Featured.jsx
+++ b/client/src/sections/Featured.jsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Grid, Image, Divider } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import SectionHeader from "../components/SectionHeader";
 import FeaturedImage from "../components/FeaturedImage";
 import BrandButton from "../components/BrandButton";
@@ -160,28 +160,12 @@ function Featured() {
 		fillFeaturedArtistImages();
 	};
 
-	// async function getMetTestResponse() {
-	// 	const response = await fetch("/api/met/", {
-	// 		method: "GET",
-	// 	});
-	// 	const data = await response.json();
-	// 	console.log(data);
-	// }
-
-	// useEffect(() => {
-	// 	getMetTestResponse();
-	// }, []);
-
 	// const scrollBoxRef = useRef(null);
-	// const [scrollDirection, setScrollDirection] = useState({
-	// 	left: false,
-	// 	right: false,
-	// 	up: false,
-	// 	down: true,
-	// });
 
-	// // if check to see window size and set scrollDirection accordingly
 	// useEffect(() => {
+	// 	const scrollBox = scrollBoxRef.current;
+
+	// 	// if check to see window size and set scrollDirection accordingly
 	// 	if (window.innerWidth < 992) {
 	// 		setScrollDirection({
 	// 			left: false,
@@ -190,11 +174,10 @@ function Featured() {
 	// 			down: false,
 	// 		});
 	// 	}
-	// }, [loading]);
 
-	// useEffect(() => {
-	// 	const scrollBox = scrollBoxRef.current;
-	// 	// const isScrollable = scrollBox.scrollWidth > scrollBox.clientWidth;
+	// 	if (!scrollBox) {
+	// 		return;
+	// 	}
 
 	// 	const handleScroll = () => {
 	// 		const isScrollableX = scrollBox.scrollWidth > scrollBox.clientWidth;
@@ -219,7 +202,7 @@ function Featured() {
 	// 		scrollBox.removeEventListener("scroll", handleScroll);
 	// 		window.removeEventListener("resize", handleScroll);
 	// 	};
-	// }, [loading]);
+	// }, [loadingArt]);
 
 	// useEffect(() => {
 	// 	console.log(scrollDirection);
@@ -230,28 +213,22 @@ function Featured() {
 			<SectionHeader headerText="Featured Artist" />
 			<Grid
 				templateColumns={{ base: "1fr", lg: "2.5fr .25fr 3fr" }}
-				height={{ base: "auto", lg: "40vw" }}
-				mx={{ base: "0", lg: "5%" }}
-				gap="5%"
+				height={{ base: "fit-content", lg: "40vw" }}
+				mx="5%"
+				gap={{ base: "0%", lg: "5%" }}
 			>
 				{loadingArtist ? (
 					<Flex justify="center" align="center" mb={{ base: 6, lg: 0 }}>
 						<Loader />
 					</Flex>
 				) : (
-					<Flex
-						mb={{ base: 4, sm: 0 }}
-						width="100%"
-						direction="column"
-						align="center"
-						justify="space-around"
-					>
+					<Flex width="100%" direction="column" align="center" justify="space-around">
 						<Flex
 							direction="column"
-							justify="space-between"
+							justify="space-around"
 							align="center"
 							width="100%"
-							height="90%"
+							height="100%"
 						>
 							<Flex
 								justify="center"
@@ -303,7 +280,7 @@ function Featured() {
 				{windowWidth >= 992 ? (
 					<Divider mt={4} height="90%" borderColor="#B1BAC1" orientation="vertical" />
 				) : (
-					<Divider borderColor="#B1BAC1" orientation="horizontal" />
+					<Divider mt={10} mb={4} borderColor="#B1BAC1" orientation="horizontal" />
 				)}
 				{loadingArt ? (
 					<Flex justify="center" align="center" my={{ base: 6, lg: 0 }}>
@@ -312,39 +289,37 @@ function Featured() {
 				) : (
 					<Box
 						// ref={scrollBoxRef}
-						overflowY={{ base: "hidden", lg: "scroll" }}
+						overflowY={{ base: "auto", lg: "scroll" }}
 						overflowX={{ base: "scroll", lg: "hidden" }}
 						position="relative"
 						width="100%"
-						mt={{ base: 4, lg: 12 }}
+						height={{ base: "fit-content", lg: "auto" }}
 						borderRadius="md"
 					>
 						{/* <Box pointerEvents="none" width="100%" height="100%" position="absolute">
-						{scrollDirection.left && (
-							<Box position="absolute" height="100%" left="0" zIndex="1">
-								Left
-							</Box>
-						)}
-						{scrollDirection.right && (
-							<Box position="absolute" height="100%" right="0" zIndex="1">
-								Right
-							</Box>
-						)}
-						{scrollDirection.up && (
-							<Box position="absolute" width="100%" top="0" zIndex="1">
-								Up
-							</Box>
-						)}
-						{scrollDirection.down && (
-							<Box position="absolute" width="100%" bottom="0" zIndex="1">
-								Down
-							</Box>
-						)}
-					</Box> */}
+							{scrollDirection.left && (
+								<Box position="absolute" height="100%" left="0" zIndex="1">
+									Left
+								</Box>
+							)}
+							{scrollDirection.right && (
+								<Box position="absolute" height="100%" right="0" zIndex="1">
+									Right
+								</Box>
+							)}
+							{scrollDirection.up && (
+								<Box position="absolute" width="100%" top="0" zIndex="1">
+									Up
+								</Box>
+							)}
+							{scrollDirection.down && (
+								<Box position="absolute" width="100%" bottom="0" zIndex="1">
+									Down
+								</Box>
+							)}
+						</Box> */}
 						<Flex
 							direction={{ base: "row", lg: "column" }}
-							my={{ base: 4, lg: 0 }}
-							position="relative"
 							width={{ base: "330%", md: "270%", lg: "auto" }}
 							justify="space-around"
 						>

--- a/client/src/sections/SiteMap.jsx
+++ b/client/src/sections/SiteMap.jsx
@@ -36,13 +36,7 @@ function SiteMap() {
 								"Displays",
 								"Admissions",
 							]}
-							links={[
-								"/",
-								"/link",
-								"/link",
-								"/link",
-								"/link",
-							]}
+							links={["/", "/link", "/link", "/link", "/link"]}
 						/>
 						<MapComponent
 							headingText="Elias Spector-Zabusky"

--- a/client/src/sections/Visit.jsx
+++ b/client/src/sections/Visit.jsx
@@ -82,12 +82,17 @@ function Visit() {
 	}, []);
 
 	return (
-		<Box py={6} width="100%" bgColor="gray.100">
+		<Box
+			py={6}
+			width="100%"
+			bgColor="gray.100"
+			boxShadow="inset 4px 4px 10px rgba(0, 0, 0, 0.2), inset -4px -4px 10px rgba(0, 0, 0, 0.2)"
+		>
 			<Box mx={{ sm: 8, md: 8, lg: 16 }}>
 				<SectionHeader headerText="Visit Us" />
 				<Flex
 					direction={{ base: "column", md: "row" }}
-					justify={{base: "space-between", md: "space-around"}}
+					justify={{ base: "space-between", md: "space-around" }}
 					align={{ base: "center", md: "center" }}
 					wrap="no-wrap"
 					mx="10%"
@@ -116,18 +121,18 @@ function Visit() {
 							boxShadow="4px 4px 4px 4px rgba(0, 0, 0, 0.2)"
 							alignSelf="center"
 							mb={{ base: "3", md: "3" }}
-							py={{ base: "3", md: "3"}}
+							py={{ base: "3", md: "3" }}
 						>
 							<CardBody textStyle="playfairBold">
-							<Heading
-								variant="exhibit-heading"
-								textAlign="center"
-								fontSize="1.25em"
-								// pb={0}
-								// mb="1em"
-							>
-								{"The museum is currently " + status}
-							</Heading>
+								<Heading
+									variant="exhibit-heading"
+									textAlign="center"
+									fontSize="1.25em"
+									// pb={0}
+									// mb="1em"
+								>
+									{"The museum is currently " + status}
+								</Heading>
 							</CardBody>
 						</Card>
 						<ButtonArray links={links} padding={0} />


### PR DESCRIPTION
Okay, a whole bunch.

This centers the loaders within their own component so I could center them in the space they occupy for desktop and mobile.

More work on the on scroll gradient for the scrollbox – couldn't solve a few simultaneous issues, so pivoted.

In adding box shadows to all components, found a nice solution for the scrollable box that indicates the available movement with an inset boxshadow. Should potentially account for scrollbar.